### PR TITLE
Add "ConfigureServices" configure windows authentication in ASP.NET Core

### DIFF
--- a/Scenarios/Getting-Started-with-CoreWCF/NetCoreServer/Program.cs
+++ b/Scenarios/Getting-Started-with-CoreWCF/NetCoreServer/Program.cs
@@ -2,8 +2,10 @@
 using System.Net;
 using CoreWCF.Configuration;
 using Microsoft.AspNetCore;
+using Microsoft.AspNetCore.Authentication.Negotiate;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace NetCoreServer
 {
@@ -28,6 +30,10 @@ namespace NetCoreServer
                         listenOptions.UseConnectionLogging();
                     }
                 });
+            })
+            .ConfigureServices(options =>
+            {
+                options.AddAuthentication(NegotiateDefaults.AuthenticationScheme).AddNegotiate();
             })
             .UseNetTcp(Startup.NETTCP_PORT)
             .UseStartup<Startup>();


### PR DESCRIPTION
I ran the sample and got the following exception, so I added a workaround.

"System.InvalidOperationException: Unable to resolve service for type 'Microsoft.AspNetCore.Authentication.IAuthenticationSchemeProvider' while attempting to activate 'Microsoft.AspNetCore.Authentication.AuthenticationMiddleware'."

Thank you for the sample.