### PR TITLE
Add rabbitmq sample projects

### DIFF
--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/EchoService.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/EchoService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace RabbitMQ_Basic;
+
+public class EchoService : IEchoService
+{
+    public string Echo(string text)
+    {
+        System.Console.WriteLine($"Received {text} from client!");
+        return text;
+    }
+
+    public string ComplexEcho(EchoMessage text)
+    {
+        System.Console.WriteLine($"Received {text.Text} from client!");
+        return text.Text;
+    }
+
+    public string FailEcho(string text)
+        => throw new FaultException<EchoFault>(new EchoFault() { Text = "WCF Fault OK" }, new FaultReason("FailReason"));
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/IEchoService.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/IEchoService.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace RabbitMQ_Basic
+{
+    [DataContract]
+    public class EchoFault
+    {
+        [DataMember]
+        [AllowNull]
+        public string Text { get; set; }
+    }
+
+    [ServiceContract]
+    public interface IEchoService
+    {
+        [OperationContract]
+        string Echo(string text);
+
+        [OperationContract]
+        string ComplexEcho(EchoMessage text);
+
+        [OperationContract]
+        [FaultContract(typeof(EchoFault))]
+        string FailEcho(string text);
+    }
+
+    [DataContract]
+    public class EchoMessage
+    {
+        [AllowNull]
+        [DataMember]
+        public string Text { get; set; }
+    }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/Program.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/Program.cs
@@ -1,0 +1,27 @@
+﻿using System.Net;
+
+var builder = WebApplication.CreateBuilder();
+builder.Services.AddServiceModelServices();
+builder.Services.AddQueueTransport();
+builder.Services.AddServiceModelMetadata();
+builder.Services.AddSingleton<IServiceBehavior, UseRequestHeadersForMetadataAddressBehavior>();
+
+var app = builder.Build();
+var rabbitMqHostUri = new Uri("net.amqp://HOST:PORT/amq.direct/QUEUE_NAME#ROUTING_KEY");
+var credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
+
+app.UseServiceModel(serviceBuilder =>
+{
+    serviceBuilder.AddService<EchoService>();
+    serviceBuilder.AddServiceEndpoint<EchoService, IEchoService>(
+        new RabbitMqBinding
+        {
+            Credentials = credentials,
+            QueueConfiguration = new QuorumQueueConfiguration()
+        },
+        rabbitMqHostUri);
+    var serviceMetadataBehavior = app.Services.GetRequiredService<ServiceMetadataBehavior>();
+    serviceMetadataBehavior.HttpsGetEnabled = true;
+});
+
+app.Run();

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/Properties/launchSettings.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "RabbitMQ_Basic": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:7099;http://localhost:5157"
+    }
+  }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/RabbitMQ_Basic.csproj
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/RabbitMQ_Basic.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Using Include="CoreWCF" />
+    <Using Include="CoreWCF.Configuration" />
+    <Using Include="CoreWCF.Channels" />
+    <Using Include="CoreWCF.Description" />
+    <Using Include="System.Runtime.Serialization " />
+    <Using Include="RabbitMQ_Basic" />
+    <Using Include="Microsoft.Extensions.DependencyInjection.Extensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CoreWCF.Primitives" Version="1.3.1" />
+    <PackageReference Include="CoreWCF.Http" Version="1.*" />
+  </ItemGroup>
+</Project>

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/RabbitMQ_Basic.sln
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/RabbitMQ_Basic.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RabbitMQ_Basic", "RabbitMQ_Basic.csproj", "{CC514F4A-110C-4E6A-9ED6-BE1A9AE3E326}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CC514F4A-110C-4E6A-9ED6-BE1A9AE3E326}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC514F4A-110C-4E6A-9ED6-BE1A9AE3E326}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC514F4A-110C-4E6A-9ED6-BE1A9AE3E326}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC514F4A-110C-4E6A-9ED6-BE1A9AE3E326}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4AF6709A-681C-4995-A51D-12F6D8F1BC69}
+	EndGlobalSection
+EndGlobal

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/appsettings.Development.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_Basic/appsettings.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_Basic/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/EchoService.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/EchoService.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+namespace RabbitMQ_TLS;
+
+public class EchoService : IEchoService
+{
+    public string Echo(string text)
+    {
+        System.Console.WriteLine($"Received {text} from client!");
+        return text;
+    }
+
+    public string ComplexEcho(EchoMessage text)
+    {
+        System.Console.WriteLine($"Received {text.Text} from client!");
+        return text.Text;
+    }
+
+    public string FailEcho(string text)
+        => throw new FaultException<EchoFault>(new EchoFault() { Text = "WCF Fault OK" }, new FaultReason("FailReason"));
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/IEchoService.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/IEchoService.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace RabbitMQ_TLS
+{
+    [DataContract]
+    public class EchoFault
+    {
+        [DataMember]
+        [AllowNull]
+        public string Text { get; set; }
+    }
+
+    [ServiceContract]
+    public interface IEchoService
+    {
+        [OperationContract]
+        string Echo(string text);
+
+        [OperationContract]
+        string ComplexEcho(EchoMessage text);
+
+        [OperationContract]
+        [FaultContract(typeof(EchoFault))]
+        string FailEcho(string text);
+    }
+
+    [DataContract]
+    public class EchoMessage
+    {
+        [AllowNull]
+        [DataMember]
+        public string Text { get; set; }
+    }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/Program.cs
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/Program.cs
@@ -1,0 +1,33 @@
+﻿using System.Net;
+
+var builder = WebApplication.CreateBuilder();
+builder.Services.AddServiceModelServices();
+builder.Services.AddQueueTransport();
+builder.Services.AddServiceModelMetadata();
+builder.Services.AddSingleton<IServiceBehavior, UseRequestHeadersForMetadataAddressBehavior>();
+
+var app = builder.Build();
+var rabbitMqHostUri = new Uri("net.amqps://HOST:PORT/amq.direct/QUEUE_NAME#ROUTING_KEY");
+var sslOption = new SslOption
+{
+    ServerName = rabbitMqHostUri.Host,
+    Enabled = true
+};
+var credentials = new NetworkCredential(ConnectionFactory.DefaultUser, ConnectionFactory.DefaultPass);
+
+app.UseServiceModel(serviceBuilder =>
+{
+    serviceBuilder.AddService<EchoService>();
+    serviceBuilder.AddServiceEndpoint<EchoService, IEchoService>(
+        new RabbitMqBinding
+        {
+            SslOption = sslOption,
+            Credentials = credentials,
+            QueueConfiguration = new ClassicQueueConfiguration()
+        },
+        rabbitMqHostUri);
+    var serviceMetadataBehavior = app.Services.GetRequiredService<ServiceMetadataBehavior>();
+    serviceMetadataBehavior.HttpsGetEnabled = true;
+});
+
+app.Run();

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/Properties/launchSettings.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/Properties/launchSettings.json
@@ -1,0 +1,11 @@
+{
+  "profiles": {
+    "RabbitMQ_TLS": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "https://localhost:7243;http://localhost:5172"
+    }
+  }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/RabbitMQ_TLS.csproj
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/RabbitMQ_TLS.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <Using Include="CoreWCF" />
+    <Using Include="CoreWCF.Configuration" />
+    <Using Include="CoreWCF.Channels" />
+    <Using Include="CoreWCF.Description" />
+    <Using Include="System.Runtime.Serialization " />
+    <Using Include="RabbitMQ_TLS" />
+    <Using Include="Microsoft.Extensions.DependencyInjection.Extensions" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CoreWCF.Primitives" Version="1.3.1" />
+    <PackageReference Include="CoreWCF.Http" Version="1.*" />
+  </ItemGroup>
+</Project>

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/RabbitMQ_TLS.sln
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/RabbitMQ_TLS.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33110.190
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RabbitMQ_TLS", "RabbitMQ_TLS.csproj", "{2F6FEDD2-5C9B-4305-A825-3EFC2474AA11}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2F6FEDD2-5C9B-4305-A825-3EFC2474AA11}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2F6FEDD2-5C9B-4305-A825-3EFC2474AA11}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2F6FEDD2-5C9B-4305-A825-3EFC2474AA11}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2F6FEDD2-5C9B-4305-A825-3EFC2474AA11}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {2A0B019A-1201-4A29-9D15-55E5ACC2AD42}
+	EndGlobalSection
+EndGlobal

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/appsettings.Development.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/Basic/Binding/RabbitMQ/RabbitMQ_TLS/appsettings.json
+++ b/Basic/Binding/RabbitMQ/RabbitMQ_TLS/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}


### PR DESCRIPTION
## [PENDING DRAFT PR] 

Added two sample projects for RabbitMQ as a transport layer based on the CoreWCF [queueing feature branch](https://github.com/CoreWCF/CoreWCF/tree/feature/queue):

* CoreWCF server with a basic RabbitMQ endpoint (no TLS enabled)
* CoreWCF server with a TLS-enabled RabbitMQ endpoint

### TODO: 
* In both projects, add package reference to `CoreWCF.Queue`
* In both projects, add package reference to `CoreWCF.RabbitMQ`