### PR TITLE
fix: resolve issue by enabling synchronous IO in Kestrel configuration

### DIFF
--- a/Scenarios/Getting-Started-with-CoreWCF/WebHttp/Startup.cs
+++ b/Scenarios/Getting-Started-with-CoreWCF/WebHttp/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using CoreWCF;
 using CoreWCF.Configuration;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.DependencyInjection;
 using Swashbuckle.AspNetCore.Swagger;
 using System.Xml;
@@ -24,6 +25,10 @@ internal sealed class Startup
         });
 
         services.AddSingleton(new SwaggerOptions());
+        services.Configure<KestrelServerOptions>(options =>
+        {
+            options.AllowSynchronousIO = true;
+        });
     }
 
     public void Configure(IApplicationBuilder app)


### PR DESCRIPTION
fix: resolve client-side exception by enabling synchronous IO in Kestrel configuration

Fixed the issue causing WebHttpClient.ApiException: "The HTTP status code of the response was not expected (500)" by configuring Kestrel to allow synchronous IO.
